### PR TITLE
Rename the bins referred in relay and clock dev scripts

### DIFF
--- a/dev/clock
+++ b/dev/clock
@@ -16,4 +16,4 @@ SCHEME="${SCHEME:-https}"
 # Combine the host and name into a URL.
 URL="${URL:-"$SCHEME://$ADDR"}"
 
-cargo run --bin moq-clock -- "$URL" "$@"
+cargo run --bin moq-clock-ietf -- "$URL" "$@"

--- a/dev/relay
+++ b/dev/relay
@@ -36,4 +36,4 @@ fi
 echo "Publish URL: https://quic.video/publish/?server=localhost:$PORT"
 
 # Run the relay and forward any arguments
-cargo run --bin moq-relay -- --bind "$BIND" --tls-cert "$CERT" --tls-key "$KEY" --dev $ARGS -- "$@"
+cargo run --bin moq-relay-ietf -- --bind "$BIND" --tls-cert "$CERT" --tls-key "$KEY" --dev $ARGS -- "$@"


### PR DESCRIPTION
The PR hosts the minor changes renaming the relay and clock bins invoked in ./dev/relay and ./dev/clock scripts. To address the below error:

 ./dev/relay
Publish URL: https://quic.video/publish/?server=localhost:4443
  Downloaded rustc-hash v2.0.0
  Downloaded quinn-proto v0.11.8
  Downloaded 2 crates (216.9 KB) in 0.58s
error: no bin target named `moq-relay`.
Available bin targets:
    moq-api
    moq-clock-ietf
    moq-dir
    moq-pub
    moq-relay-ietf
    moq-sub


Related to [moq-relay-ietf: Rename crate](https://github.com/englishm/moq-rs/commit/7ac2ff9625daa54c1cfd1741f96a1ec3636d1627) and [moq-clock-ietf: Rename crate](https://github.com/englishm/moq-rs/commit/2d559e228f55b70c98cb97eb668663679e62aaa4)