### PR TITLE
Address subscriber_priority decode

### DIFF
--- a/moq-transport/src/message/subscribe.rs
+++ b/moq-transport/src/message/subscribe.rs
@@ -37,7 +37,7 @@ impl Decode for Subscribe {
 		let track_namespace = String::decode(r)?;
 		let track_name = String::decode(r)?;
 
-		let subscriber_priority = u8::decode(r)?;
+		let subscriber_priority = u64::decode(r)?;
 		let group_order = GroupOrder::decode(r)?;
 
 		let filter_type = FilterType::decode(r)?;
@@ -87,7 +87,7 @@ impl Decode for Subscribe {
 			track_alias,
 			track_namespace,
 			track_name,
-			subscriber_priority,
+			subscriber_priority: subscriber_priority.try_into().map_err(|_| DecodeError::InvalidValue)?,
 			group_order,
 			filter_type,
 			start,


### PR DESCRIPTION
This PR holds the changes to address the issue mentioned in https://github.com/englishm/moq-rs/pull/8#issuecomment-2445386335 .

With this commit https://github.com/englishm/moq-rs/commit/7eeecb7639ea6a14ded1d49eb45aef1818b32965 , the subscribe_priority was set as 127

"subscriber_priority: 127, // default to mid value, see: https://github.com/moq-wg/moq-transport/issues/504"

The current code seems to encode ( code reference  varint.rs ) subscribe_priority values less than 64 as u8 , above this it seems to encode it as u16 , due to which u8::decode on subscriber_priority value of 127 seems to  result in "decode error: fill buffer" , for values above 64 we would see this error , to accomodate values from 0-255 ( u8 ) ,with this PR the issue is attempted to be addressed with minimal changes, eventually we might need to visit encoding and decoding implementation once we have clarity on the values for subscriber_priority



