### PR TITLE
Defend crash due to probable buffer issues while attempting to decode u8

### DIFF
--- a/moq-transport/src/coding/varint.rs
+++ b/moq-transport/src/coding/varint.rs
@@ -255,6 +255,7 @@ impl Encode for u8 {
 
 impl Decode for u8 {
 	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+		Self::decode_remaining(r, 1)?;
 		Ok(r.get_u8())
 	}
 }


### PR DESCRIPTION
The PR holds minor changes to defend crashe due to probable buffer issues while attempting to decode u8.

At times crash was observed during decoding u8 while testing interop with draft-05 Publish endpoint of moq-js.